### PR TITLE
hotfix/rescue_utf_7 add rescue to force encode to UTF-8

### DIFF
--- a/lib/httparty/parser.rb
+++ b/lib/httparty/parser.rb
@@ -100,7 +100,13 @@ module HTTParty
     def parse
       return nil if body.nil?
       return nil if body == "null"
-      return nil if body.valid_encoding? && body.strip.empty?
+      begin
+        return nil if body.valid_encoding? && body.strip.empty?
+      rescue Encoding::CompatibilityError
+        body.force_encoding('UTF-8')
+      ensure
+        return nil if body.valid_encoding? && body.strip.empty?
+      end
       if supports_format?
         parse_supported_format
       else


### PR DESCRIPTION
# issue
- when fetching orders for a WooCommerce store, this error was raised: "incompatible encoding with this operation: UTF-7"

# solution
- [x] add rescue to force encode to UTF-8

